### PR TITLE
Fix parsing features for new devices

### DIFF
--- a/toshiba_ac/device.py
+++ b/toshiba_ac/device.py
@@ -102,7 +102,7 @@ class ToshibaAcDevice:
 
     def load_supported_merit_features(self, merit_feature_hexstring, ac_model_id):
         try:
-            merit_byte, = struct.unpack('b', bytes.fromhex(merit_feature_hexstring[:2]))
+            merit_byte, = struct.unpack('B', bytes.fromhex(merit_feature_hexstring[:2]))
         except (TypeError, ValueError, struct.error):
             ac_model_id = '1'
 

--- a/toshiba_ac/fcu_state.py
+++ b/toshiba_ac/fcu_state.py
@@ -139,13 +139,13 @@ class ToshibaAcFcuState:
                 ToshibaAcFcuState.AcNone.NONE,
                 ToshibaAcFcuState.AcNone.NONE,
                 ToshibaAcFcuState.AcNone.NONE)
-        encoded = struct.pack('bbbbbbbbbbbbbbbbbbbb', *[prop.value for prop in data]).hex()
+        encoded = struct.pack('BBBBBBBBBBBBBBBBBBBB', *[prop.value for prop in data]).hex()
         return encoded[:12] + encoded[13] + encoded[15] + encoded[16:] # Merit A/B features are encoded using half bytes but our packing added them as bytes
 
 
     def decode(self, hex_state):
         extended_hex_state = hex_state[:12] + '0' + hex_state[12] + '0' + hex_state[13:] # Merit A/B features are encoded using half bytes but our unpacking expect them as bytes
-        data = struct.unpack('bbbbbbbbbbbbbbbbbbbb', bytes.fromhex(extended_hex_state))
+        data = struct.unpack('BBBBBBBBBBBBBBBBBBBB', bytes.fromhex(extended_hex_state))
         (self.ac_status,
         self.ac_mode,
         self.ac_temperature,

--- a/toshiba_ac/fcu_state.py
+++ b/toshiba_ac/fcu_state.py
@@ -139,13 +139,13 @@ class ToshibaAcFcuState:
                 ToshibaAcFcuState.AcNone.NONE,
                 ToshibaAcFcuState.AcNone.NONE,
                 ToshibaAcFcuState.AcNone.NONE)
-        encoded = struct.pack('BBBBBBBBBBBBBBBBBBBB', *[prop.value for prop in data]).hex()
+        encoded = struct.pack('bbbbbbbbbbbbbbbbbbbb', *[prop.value for prop in data]).hex()
         return encoded[:12] + encoded[13] + encoded[15] + encoded[16:] # Merit A/B features are encoded using half bytes but our packing added them as bytes
 
 
     def decode(self, hex_state):
         extended_hex_state = hex_state[:12] + '0' + hex_state[12] + '0' + hex_state[13:] # Merit A/B features are encoded using half bytes but our unpacking expect them as bytes
-        data = struct.unpack('BBBBBBBBBBBBBBBBBBBB', bytes.fromhex(extended_hex_state))
+        data = struct.unpack('bbbbbbbbbbbbbbbbbbbb', bytes.fromhex(extended_hex_state))
         (self.ac_status,
         self.ac_mode,
         self.ac_temperature,


### PR DESCRIPTION
I tested the proposed solution on my new devices with the bundled script
and home-assistant-toshiba_ac . Both tests were successful.

For future reference, my devices are:
* Toshiba SHORAI EDGE RAS-B13N4KVSG-E UI
* Toshiba RAS-2M18U2AVG-E U.E.MULTISPLIT
* Toshiba SEIYA RAS-B13J2KVG-E UI