### PR TITLE
Bump aiohttp to 3.8.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     azure-iot-device==2.9.0
-    aiohttp==3.8.1
+    aiohttp==3.8.3
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
This fixes compatibility with the Home Assistant HACS addon on the latest HA OS beta.