### PR TITLE
Ignore extra AMQP data

### DIFF
--- a/toshiba_ac/device/fcu_state.py
+++ b/toshiba_ac/device/fcu_state.py
@@ -306,7 +306,7 @@ class ToshibaAcFcuState:
 
     def decode(self, hex_state: str) -> None:
         extended_hex_state = (
-            hex_state[:12] + "0" + hex_state[12] + "0" + hex_state[13:38] # Toshiba sometimes responds with more than 38 bytes (maybe some extra data, but we ignore it by stopping at the 38th byte)
+            hex_state[:12] + "0" + hex_state[12] + "0" + hex_state[13:38] # Toshiba sometimes responds with more than 19 bytes (maybe some extra data, but we ignore it by stopping at the 38th hex value)
         )  # Merit A/B features are encoded using half bytes but our unpacking expect them as bytes
         data = self.ENCODING_STRUCT.unpack(bytes.fromhex(extended_hex_state))
         (

--- a/toshiba_ac/device/fcu_state.py
+++ b/toshiba_ac/device/fcu_state.py
@@ -306,7 +306,7 @@ class ToshibaAcFcuState:
 
     def decode(self, hex_state: str) -> None:
         extended_hex_state = (
-            hex_state[:12] + "0" + hex_state[12] + "0" + hex_state[13:]
+            hex_state[:12] + "0" + hex_state[12] + "0" + hex_state[13:38] # Toshiba sometimes responds with more than 38 bytes (maybe some extra data, but we ignore it by stopping at the 38th byte)
         )  # Merit A/B features are encoded using half bytes but our unpacking expect them as bytes
         data = self.ENCODING_STRUCT.unpack(bytes.fromhex(extended_hex_state))
         (


### PR DESCRIPTION
As initially found by @PatrickTaibel in https://github.com/KaSroka/Toshiba-AC-control/issues/50, Toshiba started to sometimes send more than 19 bytes in AMQP responses.

It is still unknown if the extra data adds some new capabilities as I currently do not have enough time resources available to reverse engineer new builds of the Android app.

I have however tested and made sure that ignoring the extra data does not break current functionality (tested on two different models of Toshiba WiFi Adapters).

This pull request can be merged to make this library work while the meaning of the new data is still being analysed.

Again, huge thanks to @PatrickTaibel for initially finding and reporting this here on this repo!

Edit: When this PR is merged, please also release a publicly available version to pip, so downstream projects like https://github.com/h4de5/home-assistant-toshiba_ac can implement the fix. Thanks :)