### PR TITLE
Fix for random rejects from server

### DIFF
--- a/toshiba_ac/utils/http_api.py
+++ b/toshiba_ac/utils/http_api.py
@@ -81,7 +81,9 @@ class ToshibaAcHttpApi:
             headers = {}
             headers["Content-Type"] = "application/json"
             headers["Authorization"] = self.access_token_type + " " + self.access_token
-            headers["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+            headers["User-Agent"] = (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+            )
 
         url = self.BASE_URL + path
 
@@ -117,7 +119,7 @@ class ToshibaAcHttpApi:
     async def connect(self) -> None:
         headers = {
             "Content-Type": "application/json",
-            "User-Agent" : "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
         }
         post = {"Username": self.username, "Password": self.password}
 

--- a/toshiba_ac/utils/http_api.py
+++ b/toshiba_ac/utils/http_api.py
@@ -81,6 +81,7 @@ class ToshibaAcHttpApi:
             headers = {}
             headers["Content-Type"] = "application/json"
             headers["Authorization"] = self.access_token_type + " " + self.access_token
+            headers["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
 
         url = self.BASE_URL + path
 
@@ -114,7 +115,10 @@ class ToshibaAcHttpApi:
             raise ToshibaAcHttpApiError(await response.text())
 
     async def connect(self) -> None:
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent" : "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+        }
         post = {"Username": self.username, "Password": self.password}
 
         res = await self.request_api(self.LOGIN_PATH, post=post, headers=headers)


### PR DESCRIPTION
Hi,

as described on the issue I reported, the servers will reject randomly the requests even if the credentials are okay. This is a countermeasure against third party systems that consume their APIs such as your's (and behind Home assistant).

I had the exact same problem on the Electrolux integration that I maintain. The trick is to submit a well-known user agent, if possible the same one as the one provided by the app.

I have tested this fix successfully and now I don't have any more rejects from the server