### PR TITLE
build and publish wheel

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,7 +19,9 @@ jobs:
       with:
         python-version: "3.9"
     - name: Create distribution 📦
-      run: python setup.py sdist
+      run: |
+        python -m pip install build
+        python -m build
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Currently this project publishes only a source distribution.  Better to publish a wheel too, else every user has to build one for themselves.