### PR TITLE
Add HADA Care Flow swing mode (raw 0x60)

### DIFF
--- a/toshiba_ac/device/fcu_state.py
+++ b/toshiba_ac/device/fcu_state.py
@@ -132,6 +132,7 @@ class ToshibaAcFcuState:
                 0x52: ToshibaAcSwingMode.FIXED_3,
                 0x53: ToshibaAcSwingMode.FIXED_4,
                 0x54: ToshibaAcSwingMode.FIXED_5,
+                0x60: ToshibaAcSwingMode.HADA_CARE_FLOW,
                 0x00: ToshibaAcSwingMode.NONE,
                 ToshibaAcFcuState.NONE_VAL: ToshibaAcSwingMode.NONE,
             }[raw]
@@ -148,6 +149,7 @@ class ToshibaAcFcuState:
                 ToshibaAcSwingMode.FIXED_3: 0x52,
                 ToshibaAcSwingMode.FIXED_4: 0x53,
                 ToshibaAcSwingMode.FIXED_5: 0x54,
+                ToshibaAcSwingMode.HADA_CARE_FLOW: 0x60,
                 ToshibaAcSwingMode.NONE: ToshibaAcFcuState.NONE_VAL,
             }[swing_mode]
 

--- a/toshiba_ac/device/properties.py
+++ b/toshiba_ac/device/properties.py
@@ -60,6 +60,7 @@ class ToshibaAcSwingMode(Enum):
     FIXED_3 = auto()
     FIXED_4 = auto()
     FIXED_5 = auto()
+    HADA_CARE_FLOW = auto()
     NONE = None
 
 


### PR DESCRIPTION
## Summary

Some Toshiba units report swing raw value **`0x60`** for **HADA Care Flow** — Toshiba's indirect-airflow mode that directs air upward toward the ceiling for even temperature distribution (shown as **"H.DA"** in the official Toshiba Home AC Control app).

`0x60` is missing from `AcSwingMode.from_raw`, so `from_raw(0x60)` raises `KeyError: 96`.

This is **not cosmetic**. Any consumer that reads `ac_swing_mode` crashes — including `ToshibaAcDevice.send_state_to_ac`, which evaluates `future_state.ac_swing_mode` to validate supported modes before sending. Downstream (e.g. the [h4de5 Home Assistant integration](https://github.com/h4de5/home-assistant-toshiba_ac)) this means: the climate entity fails to be created at setup, and every `set_temperature` / `set_hvac_mode` / `set_fan_mode` raises HTTP 500. Reported there as h4de5/home-assistant-toshiba_ac#226 and #287.

## How the value was identified

On a Toshiba unit (firmware `1.5.00`), I cycled the official app through every swing option and decoded **byte 4** of the AMQP state payload (`AC state from AMQP: ........XX....`):

| App option | byte 4 | Enum |
|---|---|---|
| Vertical swing | `0x41` | `SWING_VERTICAL` ✓ |
| Horizontal swing | `0x42` | `SWING_HORIZONTAL` ✓ |
| Vertical + Horizontal | `0x43` | `SWING_VERTICAL_AND_HORIZONTAL` ✓ |
| Off (🚫) | `0x31` | `OFF` ✓ |
| Fixed 1–5 | `0x50`–`0x54` | `FIXED_1`…`FIXED_5` ✓ |
| **H.DA** | **`0x60`** | **(unmapped → `KeyError`)** |

`0x60` is the only value the device emits that the library does not handle.

## Changes

- `properties.py`: add `ToshibaAcSwingMode.HADA_CARE_FLOW`
- `fcu_state.py`: map `0x60` in `AcSwingMode.from_raw` and the inverse in `to_raw`

Three lines added, no behaviour change for existing values. `python -m py_compile` clean.

## Scope note

This intentionally does **not** add `HADA_CARE_FLOW` to the supported-modes detection in `features.py`. The fixed positions there are gated on `ac_model_id == "3"` + `merit_bits[14]`; the merit bit that advertises HADA support is unknown, and guessing it risks mis-advertising the mode on models that lack it. That can follow once the bit is identified across more devices. This change alone removes the crash and makes the mode round-trip correctly (read + set).

## Testing

- `from_raw(0x60)` → `ToshibaAcSwingMode.HADA_CARE_FLOW`
- `to_raw(ToshibaAcSwingMode.HADA_CARE_FLOW)` → `0x60`
- Live: with the value mapped, the climate entity loads and commands round-trip; AMQP confirms the unit accepting state changes.