### PR TITLE
Defensive enum handling: fallback to UNKNOWN for unrecognized raw values

### DIFF
--- a/toshiba_ac/device/fcu_state.py
+++ b/toshiba_ac/device/fcu_state.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 import struct
 import typing as t
 
@@ -29,6 +30,8 @@ from toshiba_ac.device.properties import (
     ToshibaAcSwingMode,
 )
 
+LOGGER = logging.getLogger(__name__)
+
 
 class ToshibaAcFcuState:
     NONE_VAL = 0xFF
@@ -41,23 +44,31 @@ class ToshibaAcFcuState:
         def from_raw(raw: int) -> t.Optional[int]:
             raw_to_temp: t.Dict[int, t.Optional[int]] = {i: i for i in range(-128, 128)}
             raw_to_temp.update({127: None, -128: None, ToshibaAcFcuState.NONE_VAL_SIGNED: None, 126: -1})
-            return raw_to_temp[raw]
+            if raw in raw_to_temp:
+                return raw_to_temp[raw]
+            return raw
 
         @staticmethod
         def to_raw(temperature: t.Optional[int]) -> int:
             temp_to_raw: t.Dict[t.Optional[int], int] = {i: i for i in range(-128, 128)}
             temp_to_raw.update({None: ToshibaAcFcuState.NONE_VAL_SIGNED, -1: 126})
-            return temp_to_raw[temperature]
+            if temperature in temp_to_raw:
+                return temp_to_raw[temperature]
+            return ToshibaAcFcuState.NONE_VAL_SIGNED
 
     class AcStatus:
         @staticmethod
         def from_raw(raw: int) -> ToshibaAcStatus:
-            return {
+            mapping: dict[int, ToshibaAcStatus] = {
                 0x30: ToshibaAcStatus.ON,
                 0x31: ToshibaAcStatus.OFF,
                 0x02: ToshibaAcStatus.NONE,
                 ToshibaAcFcuState.NONE_VAL: ToshibaAcStatus.NONE,
-            }[raw]
+            }
+            if raw in mapping:
+                return mapping[raw]
+            LOGGER.warning("Unknown raw status value: 0x%02X (%d), returning UNKNOWN", raw, raw)
+            return ToshibaAcStatus.UNKNOWN
 
         @staticmethod
         def to_raw(status: ToshibaAcStatus) -> int:
@@ -65,12 +76,13 @@ class ToshibaAcFcuState:
                 ToshibaAcStatus.ON: 0x30,
                 ToshibaAcStatus.OFF: 0x31,
                 ToshibaAcStatus.NONE: ToshibaAcFcuState.NONE_VAL,
+                ToshibaAcStatus.UNKNOWN: ToshibaAcFcuState.NONE_VAL,
             }[status]
 
     class AcMode:
         @staticmethod
         def from_raw(raw: int) -> ToshibaAcMode:
-            return {
+            mapping: dict[int, ToshibaAcMode] = {
                 0x41: ToshibaAcMode.AUTO,
                 0x42: ToshibaAcMode.COOL,
                 0x43: ToshibaAcMode.HEAT,
@@ -78,7 +90,11 @@ class ToshibaAcFcuState:
                 0x45: ToshibaAcMode.FAN,
                 0x00: ToshibaAcMode.NONE,
                 ToshibaAcFcuState.NONE_VAL: ToshibaAcMode.NONE,
-            }[raw]
+            }
+            if raw in mapping:
+                return mapping[raw]
+            LOGGER.warning("Unknown raw mode value: 0x%02X (%d), returning UNKNOWN", raw, raw)
+            return ToshibaAcMode.UNKNOWN
 
         @staticmethod
         def to_raw(mode: ToshibaAcMode) -> int:
@@ -89,12 +105,13 @@ class ToshibaAcFcuState:
                 ToshibaAcMode.DRY: 0x44,
                 ToshibaAcMode.FAN: 0x45,
                 ToshibaAcMode.NONE: ToshibaAcFcuState.NONE_VAL,
+                ToshibaAcMode.UNKNOWN: ToshibaAcFcuState.NONE_VAL,
             }[mode]
 
     class AcFanMode:
         @staticmethod
         def from_raw(raw: int) -> ToshibaAcFanMode:
-            return {
+            mapping: dict[int, ToshibaAcFanMode] = {
                 0x41: ToshibaAcFanMode.AUTO,
                 0x31: ToshibaAcFanMode.QUIET,
                 0x32: ToshibaAcFanMode.LOW,
@@ -104,7 +121,11 @@ class ToshibaAcFcuState:
                 0x36: ToshibaAcFanMode.HIGH,
                 0x00: ToshibaAcFanMode.NONE,
                 ToshibaAcFcuState.NONE_VAL: ToshibaAcFanMode.NONE,
-            }[raw]
+            }
+            if raw in mapping:
+                return mapping[raw]
+            LOGGER.warning("Unknown raw fan mode value: 0x%02X (%d), returning UNKNOWN", raw, raw)
+            return ToshibaAcFanMode.UNKNOWN
 
         @staticmethod
         def to_raw(fan_mode: ToshibaAcFanMode) -> int:
@@ -117,12 +138,13 @@ class ToshibaAcFcuState:
                 ToshibaAcFanMode.MEDIUM_HIGH: 0x35,
                 ToshibaAcFanMode.HIGH: 0x36,
                 ToshibaAcFanMode.NONE: ToshibaAcFcuState.NONE_VAL,
+                ToshibaAcFanMode.UNKNOWN: ToshibaAcFcuState.NONE_VAL,
             }[fan_mode]
 
     class AcSwingMode:
         @staticmethod
         def from_raw(raw: int) -> ToshibaAcSwingMode:
-            return {
+            mapping: dict[int, ToshibaAcSwingMode] = {
                 0x31: ToshibaAcSwingMode.OFF,
                 0x41: ToshibaAcSwingMode.SWING_VERTICAL,
                 0x42: ToshibaAcSwingMode.SWING_HORIZONTAL,
@@ -132,9 +154,14 @@ class ToshibaAcFcuState:
                 0x52: ToshibaAcSwingMode.FIXED_3,
                 0x53: ToshibaAcSwingMode.FIXED_4,
                 0x54: ToshibaAcSwingMode.FIXED_5,
+                0x60: ToshibaAcSwingMode.HADA_CARE_FLOW,
                 0x00: ToshibaAcSwingMode.NONE,
                 ToshibaAcFcuState.NONE_VAL: ToshibaAcSwingMode.NONE,
-            }[raw]
+            }
+            if raw in mapping:
+                return mapping[raw]
+            LOGGER.warning("Unknown raw swing mode value: 0x%02X (%d), returning UNKNOWN", raw, raw)
+            return ToshibaAcSwingMode.UNKNOWN
 
         @staticmethod
         def to_raw(swing_mode: ToshibaAcSwingMode) -> int:
@@ -148,18 +175,24 @@ class ToshibaAcFcuState:
                 ToshibaAcSwingMode.FIXED_3: 0x52,
                 ToshibaAcSwingMode.FIXED_4: 0x53,
                 ToshibaAcSwingMode.FIXED_5: 0x54,
+                ToshibaAcSwingMode.HADA_CARE_FLOW: 0x60,
                 ToshibaAcSwingMode.NONE: ToshibaAcFcuState.NONE_VAL,
+                ToshibaAcSwingMode.UNKNOWN: ToshibaAcFcuState.NONE_VAL,
             }[swing_mode]
 
     class AcPowerSelection:
         @staticmethod
         def from_raw(raw: int) -> ToshibaAcPowerSelection:
-            return {
+            mapping: dict[int, ToshibaAcPowerSelection] = {
                 0x32: ToshibaAcPowerSelection.POWER_50,
                 0x4B: ToshibaAcPowerSelection.POWER_75,
                 0x64: ToshibaAcPowerSelection.POWER_100,
                 ToshibaAcFcuState.NONE_VAL: ToshibaAcPowerSelection.NONE,
-            }[raw]
+            }
+            if raw in mapping:
+                return mapping[raw]
+            LOGGER.warning("Unknown raw power selection value: 0x%02X (%d), returning UNKNOWN", raw, raw)
+            return ToshibaAcPowerSelection.UNKNOWN
 
         @staticmethod
         def to_raw(power_selection: ToshibaAcPowerSelection) -> int:
@@ -168,19 +201,24 @@ class ToshibaAcFcuState:
                 ToshibaAcPowerSelection.POWER_75: 0x4B,
                 ToshibaAcPowerSelection.POWER_100: 0x64,
                 ToshibaAcPowerSelection.NONE: ToshibaAcFcuState.NONE_VAL,
+                ToshibaAcPowerSelection.UNKNOWN: ToshibaAcFcuState.NONE_VAL,
             }[power_selection]
 
     class AcMeritB:
         @staticmethod
         def from_raw(raw: int) -> ToshibaAcMeritB:
-            return {
+            mapping: dict[int, ToshibaAcMeritB] = {
                 0x02: ToshibaAcMeritB.FIREPLACE_1,
                 0x03: ToshibaAcMeritB.FIREPLACE_2,
                 0x01: ToshibaAcMeritB.OFF,  # New value reported after update, nothing found in 3.4.0 APK version
                 0x00: ToshibaAcMeritB.OFF,
                 ToshibaAcFcuState.NONE_VAL: ToshibaAcMeritB.NONE,
                 ToshibaAcFcuState.NONE_VAL_HALF: ToshibaAcMeritB.NONE,
-            }[raw]
+            }
+            if raw in mapping:
+                return mapping[raw]
+            LOGGER.warning("Unknown raw merit B value: 0x%02X (%d), returning UNKNOWN", raw, raw)
+            return ToshibaAcMeritB.UNKNOWN
 
         @staticmethod
         def to_raw(merit_b: ToshibaAcMeritB) -> int:
@@ -189,12 +227,13 @@ class ToshibaAcFcuState:
                 ToshibaAcMeritB.FIREPLACE_2: 0x03,
                 ToshibaAcMeritB.OFF: 0x00,
                 ToshibaAcMeritB.NONE: ToshibaAcFcuState.NONE_VAL,
+                ToshibaAcMeritB.UNKNOWN: ToshibaAcFcuState.NONE_VAL,
             }[merit_b]
 
     class AcMeritA:
         @staticmethod
         def from_raw(raw: int) -> ToshibaAcMeritA:
-            return {
+            mapping: dict[int, ToshibaAcMeritA] = {
                 0x01: ToshibaAcMeritA.HIGH_POWER,
                 0x02: ToshibaAcMeritA.CDU_SILENT_1,
                 0x03: ToshibaAcMeritA.ECO,
@@ -206,7 +245,11 @@ class ToshibaAcFcuState:
                 0x00: ToshibaAcMeritA.OFF,
                 ToshibaAcFcuState.NONE_VAL: ToshibaAcMeritA.NONE,
                 ToshibaAcFcuState.NONE_VAL_HALF: ToshibaAcMeritA.NONE,
-            }[raw]
+            }
+            if raw in mapping:
+                return mapping[raw]
+            LOGGER.warning("Unknown raw merit A value: 0x%02X (%d), returning UNKNOWN", raw, raw)
+            return ToshibaAcMeritA.UNKNOWN
 
         @staticmethod
         def to_raw(merit_a: ToshibaAcMeritA) -> int:
@@ -221,16 +264,21 @@ class ToshibaAcFcuState:
                 ToshibaAcMeritA.CDU_SILENT_2: 0x0A,
                 ToshibaAcMeritA.OFF: 0x00,
                 ToshibaAcMeritA.NONE: ToshibaAcFcuState.NONE_VAL,
+                ToshibaAcMeritA.UNKNOWN: ToshibaAcFcuState.NONE_VAL,
             }[merit_a]
 
     class AcAirPureIon:
         @staticmethod
         def from_raw(raw: int) -> ToshibaAcAirPureIon:
-            return {
+            mapping: dict[int, ToshibaAcAirPureIon] = {
                 0x18: ToshibaAcAirPureIon.ON,
                 0x10: ToshibaAcAirPureIon.OFF,
                 ToshibaAcFcuState.NONE_VAL: ToshibaAcAirPureIon.NONE,
-            }[raw]
+            }
+            if raw in mapping:
+                return mapping[raw]
+            LOGGER.warning("Unknown raw air pure ion value: 0x%02X (%d), returning UNKNOWN", raw, raw)
+            return ToshibaAcAirPureIon.UNKNOWN
 
         @staticmethod
         def to_raw(air_pure_ion: ToshibaAcAirPureIon) -> int:
@@ -238,16 +286,21 @@ class ToshibaAcFcuState:
                 ToshibaAcAirPureIon.ON: 0x18,
                 ToshibaAcAirPureIon.OFF: 0x10,
                 ToshibaAcAirPureIon.NONE: ToshibaAcFcuState.NONE_VAL,
+                ToshibaAcAirPureIon.UNKNOWN: ToshibaAcFcuState.NONE_VAL,
             }[air_pure_ion]
 
     class AcSelfCleaning:
         @staticmethod
         def from_raw(raw: int) -> ToshibaAcSelfCleaning:
-            return {
+            mapping: dict[int, ToshibaAcSelfCleaning] = {
                 0x18: ToshibaAcSelfCleaning.ON,
                 0x10: ToshibaAcSelfCleaning.OFF,
                 ToshibaAcFcuState.NONE_VAL: ToshibaAcSelfCleaning.NONE,
-            }[raw]
+            }
+            if raw in mapping:
+                return mapping[raw]
+            LOGGER.warning("Unknown raw self cleaning value: 0x%02X (%d), returning UNKNOWN", raw, raw)
+            return ToshibaAcSelfCleaning.UNKNOWN
 
         @staticmethod
         def to_raw(self_cleaning: ToshibaAcSelfCleaning) -> int:
@@ -255,6 +308,7 @@ class ToshibaAcFcuState:
                 ToshibaAcSelfCleaning.ON: 0x18,
                 ToshibaAcSelfCleaning.OFF: 0x10,
                 ToshibaAcSelfCleaning.NONE: ToshibaAcFcuState.NONE_VAL,
+                ToshibaAcSelfCleaning.UNKNOWN: ToshibaAcFcuState.NONE_VAL,
             }[self_cleaning]
 
     @classmethod

--- a/toshiba_ac/device/properties.py
+++ b/toshiba_ac/device/properties.py
@@ -27,6 +27,7 @@ class ToshibaAcDeviceEnergyConsumption:
 class ToshibaAcStatus(Enum):
     ON = auto()
     OFF = auto()
+    UNKNOWN = auto()
     NONE = None
 
 
@@ -36,6 +37,7 @@ class ToshibaAcMode(Enum):
     HEAT = auto()
     DRY = auto()
     FAN = auto()
+    UNKNOWN = auto()
     NONE = None
 
 
@@ -47,6 +49,7 @@ class ToshibaAcFanMode(Enum):
     MEDIUM = auto()
     MEDIUM_HIGH = auto()
     HIGH = auto()
+    UNKNOWN = auto()
     NONE = None
 
 
@@ -60,6 +63,8 @@ class ToshibaAcSwingMode(Enum):
     FIXED_3 = auto()
     FIXED_4 = auto()
     FIXED_5 = auto()
+    HADA_CARE_FLOW = auto()
+    UNKNOWN = auto()
     NONE = None
 
 
@@ -67,6 +72,7 @@ class ToshibaAcPowerSelection(Enum):
     POWER_50 = auto()
     POWER_75 = auto()
     POWER_100 = auto()
+    UNKNOWN = auto()
     NONE = None
 
 
@@ -74,6 +80,7 @@ class ToshibaAcMeritB(Enum):
     FIREPLACE_1 = auto()
     FIREPLACE_2 = auto()
     OFF = auto()
+    UNKNOWN = auto()
     NONE = None
 
 
@@ -87,16 +94,19 @@ class ToshibaAcMeritA(Enum):
     COMFORT = auto()
     CDU_SILENT_2 = auto()
     OFF = auto()
+    UNKNOWN = auto()
     NONE = None
 
 
 class ToshibaAcAirPureIon(Enum):
     OFF = auto()
     ON = auto()
+    UNKNOWN = auto()
     NONE = None
 
 
 class ToshibaAcSelfCleaning(Enum):
     ON = auto()
     OFF = auto()
+    UNKNOWN = auto()
     NONE = None


### PR DESCRIPTION
## Problem

When Toshiba AC firmware sends raw enum values that aren't mapped in the library, every `from_raw()` method raises a `KeyError`, crashing the integration. This has been observed with:

- **Adapter firmware version 5.0.00 (indoor unit: RAS-B16N4KVRG-E)** — sends raw values `0x8C` (140) and `0x8B` (139) for swing mode, which aren't in the mapping.
- **Firmware 1.5.00 (H.DA)** — sends raw value `0x60` for "HADA Care Flow" swing mode (addressed in #80).

Any consumer/client that reads an enum property (including `send_state_to_ac`, which validates the future state's swing mode before sending) crashes, causing for example the Home Assistant integration to fail to create climate entities and reject all set commands (temperature / mode / fan).

## Solution

Instead of direct dictionary key access (`[raw]`), all `from_raw()` and `to_raw()` methods now use safe membership checks with a fallback to a new `UNKNOWN` enum member:

1. **Added `UNKNOWN` to every enum class** in `properties.py` (`ToshibaAcStatus`, `ToshibaAcMode`, `ToshibaAcFanMode`, `ToshibaAcSwingMode`, `ToshibaAcPowerSelection`, `ToshibaAcMeritB`, `ToshibaAcMeritA`, `ToshibaAcAirPureIon`, `ToshibaAcSelfCleaning`).

2. **Added `HADA_CARE_FLOW` to `ToshibaAcSwingMode`** — maps raw `0x60`, incorporating the change from #80.

3. **Rewrote all `from_raw()` methods** in `fcu_state.py` to use:
```python
mapping: dict[int, ToshibaAcSwingMode] = { ... }
if raw in mapping:
    return mapping[raw]
LOGGER.warning("Unknown raw swing mode value: x%02X (%d), returning UNKNOWN", raw, raw)
return ToshibaAcSwingMode.UNKNOWN
```
This ensures unrecognized values are logged and gracefully handled rather than crashing.

4. **Updated all `to_raw()` methods** to map `UNKNOWN` → `NONE_VAL`, so serializing an unknown value safely falls back to the "no value" sentinel instead of raising a `KeyError`.

5. **Hardened `AcTemperature.from_raw()` and `AcTemperature.to_raw()`** with the same `if in dict` pattern to prevent crashes on out-of-range raw values.

## Impact

- **No breaking changes** — all existing mappings are preserved.
- **Graceful degradation** — unknown values return `UNKNOWN` instead of crashing, allowing the integration to continue operating.
- **Observability** — a `WARNING` log line records every unknown raw value, helping identify new firmware values for future mapping additions.
- **Includes PR #80** — the HADA Care Flow (0x60) mapping is included in this PR.