### PR TITLE
Add optional BrandId support to login request

### DIFF
--- a/samples/toshiba_ac_gui.py
+++ b/samples/toshiba_ac_gui.py
@@ -45,10 +45,11 @@ class DeviceTab:
 
 
 class App(tk.Tk):
-    def __init__(self, user, password, refresh_interval=1 / 20):
+    def __init__(self, user, password, brand_id=None, refresh_interval=1 / 20):
         super().__init__()
         self.user = user
         self.password = password
+        self.brand_id = brand_id
         self.refresh_interval = refresh_interval
         self.title("Toshiba AC")
         self.protocol("WM_DELETE_WINDOW", self.close)
@@ -159,7 +160,7 @@ class App(tk.Tk):
         self.update_ac_state(self.devices[dev])
 
     async def init(self):
-        self.device_manager = ToshibaAcDeviceManager(self.user, self.password, "3e6e4eb5f0e5aa40")
+        self.device_manager = ToshibaAcDeviceManager(self.user, self.password, "3e6e4eb5f0e5aa40", brand_id=self.brand_id)
         await self.device_manager.connect()
 
         devices = await self.device_manager.get_devices()
@@ -228,16 +229,26 @@ def parse_cred():
         envvar="TOSHIBA_PASS",
         help="Toshiba Home AC password (can also be specified using TOSHIBA_PASS environment variable)",
     )
+    parser.add_argument(
+        "--brand-id",
+        metavar="brand_id",
+        dest="brand_id",
+        action=EnvDefault,
+        envvar="TOSHIBA_BRAND_ID",
+        required=False,
+        help="Toshiba brand ID (can also be specified using TOSHIBA_BRAND_ID environment variable)",
+    )
 
     cred = parser.parse_args()
 
-    return cred.user, cred.password
+    return cred.user, cred.password, cred.brand_id
 
 
 if __name__ == "__main__":
 
     async def main():
-        app = App(*parse_cred())
+        user, password, brand_id = parse_cred()
+        app = App(user, password, brand_id=brand_id)
         await app.start()
 
     asyncio.run(main())

--- a/samples/toshiba_ac_gui.py
+++ b/samples/toshiba_ac_gui.py
@@ -160,7 +160,9 @@ class App(tk.Tk):
         self.update_ac_state(self.devices[dev])
 
     async def init(self):
-        self.device_manager = ToshibaAcDeviceManager(self.user, self.password, "3e6e4eb5f0e5aa40", brand_id=self.brand_id)
+        self.device_manager = ToshibaAcDeviceManager(
+            self.user, self.password, "3e6e4eb5f0e5aa40", brand_id=self.brand_id
+        )
         await self.device_manager.connect()
 
         devices = await self.device_manager.get_devices()

--- a/toshiba_ac/device_manager.py
+++ b/toshiba_ac/device_manager.py
@@ -41,9 +41,11 @@ class ToshibaAcDeviceManager:
         password: str,
         device_id: t.Optional[str] = None,
         sas_token: t.Optional[str] = None,
+        brand_id: t.Optional[str] = None,
     ):
         self.username = username
         self.password = password
+        self.brand_id = brand_id
         self.http_api: t.Optional[ToshibaAcHttpApi] = None
         self.reg_info = None
         self.amqp_api: t.Optional[ToshibaAcAmqpApi] = None
@@ -59,7 +61,7 @@ class ToshibaAcDeviceManager:
         try:
             async with self.lock:
                 if not self.http_api:
-                    self.http_api = ToshibaAcHttpApi(self.username, self.password)
+                    self.http_api = ToshibaAcHttpApi(self.username, self.password, self.brand_id)
                     await self.http_api.connect()
 
                 if not self.sas_token:

--- a/toshiba_ac/utils/http_api.py
+++ b/toshiba_ac/utils/http_api.py
@@ -69,9 +69,10 @@ class ToshibaAcHttpApi:
     AC_STATE_PATH = "/api/AC/GetCurrentACState"
     AC_ENERGY_CONSUMPTION_PATH = "/api/AC/GetGroupACEnergyConsumption"
 
-    def __init__(self, username: str, password: str) -> None:
+    def __init__(self, username: str, password: str, brand_id: t.Optional[str] = None) -> None:
         self.username = username
         self.password = password
+        self.brand_id = brand_id
         self.access_token: t.Optional[str] = None
         self.access_token_type: t.Optional[str] = None
         self.consumer_id: t.Optional[str] = None
@@ -218,7 +219,9 @@ class ToshibaAcHttpApi:
             "Content-Type": "application/json",
             "User-Agent": self.USER_AGENT,
         }
-        post = {"Username": self.username, "Password": self.password}
+        post: dict[str, str] = {"Username": self.username, "Password": self.password}
+        if self.brand_id:
+            post["BrandId"] = self.brand_id
 
         res = await self.request_api(self.LOGIN_PATH, post=post, headers=headers)
 


### PR DESCRIPTION
## Summary

The Toshiba Home AC cloud platform is shared across multiple brands in different regions. In some countries, the same API (`mobileapi.toshibahomeaccontrols.com`) is used by co-branded or OEM products — for example, **Carrier** in Thailand uses the **"Carrier In The Air"** mobile app which authenticates against the same endpoint but requires a `BrandId` field in the login request body. Without it, authentication fails for those users.

This PR adds an optional `brand_id` parameter to `ToshibaAcHttpApi` and `ToshibaAcDeviceManager`. When set, `BrandId` is included in the login POST body. It defaults to `None`, so existing Toshiba users are completely unaffected.

Example (Carrier In The Air, Thailand):
```
BrandId: 6323a1fd-f0b8-4e56-881b-8b7c45121ff0
```

Changes:
- `ToshibaAcHttpApi.__init__` accepts optional `brand_id`
- `ToshibaAcDeviceManager.__init__` accepts and threads through `brand_id`
- GUI sample: `--brand-id` CLI flag and `TOSHIBA_BRAND_ID` env var

## Test plan

- [x] Run without `--brand-id` — login behaves as before (no `BrandId` in payload)
- [x] Run with `--brand-id 6323a1fd-f0b8-4e56-881b-8b7c45121ff0` — login succeeds for Carrier In The Air (Thailand) accounts